### PR TITLE
Update TwocheckoutApi.php To Account for UTF-8

### DIFF
--- a/lib/Twocheckout/Api/TwocheckoutApi.php
+++ b/lib/Twocheckout/Api/TwocheckoutApi.php
@@ -27,7 +27,7 @@ class Twocheckout_Api_Requester
             $data['privateKey'] = $this->privateKey;
             $data['sellerId'] = $this->sid;
             $data = json_encode($data);
-            $header = array("content-type:application/json","content-length:".strlen($data));
+            $header = array("content-type:application/json","content-length:".mb_strlen($data,'UTF-8'));
             curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "POST");
         } else {
             $header = array("Accept: application/json");


### PR DESCRIPTION
TwoCheckout used strlen() on the JSON string content-length and does not take into consideration Unicode characters that change string length.

This version uses mb_strlen() instead.
